### PR TITLE
 There's a minor bug in running the example

### DIFF
--- a/utiltiy/vec.m
+++ b/utiltiy/vec.m
@@ -1,0 +1,3 @@
+function x = vec(X)
+    x = X(:);
+end


### PR DESCRIPTION
Hello 
When using CVX 2.2 (Build 1148) with MATLAB R2024a, users may encounter the following error during quadratic form operations (quad_form): Incorrect number or types of inputs or outputs for function vec.

Root Cause Analysis:
Function Overloading Conflict: CVX defines a class method vec inside @cvx/vec.m that strictly accepts cvx objects.
MATLAB Internal Changes: In newer MATLAB versions (e.g., R2023b/R2024a), the internal logic for handling quadratic forms or certain matrix operations occasionally passes a native double matrix to vec.
Missing Fallback: Since the built-in CVX vec method does not support double inputs, and MATLAB's path resolution in newer versions might behave strictly regarding class methods, the call fails when no global vec function for double inputs is found.

Verified Solution (Workaround):
The most effective fix is to create a local "fallback" function to handle standard matrix inputs.